### PR TITLE
Update the nuspec to remove the dependency on Microsoft.Bcl.Async

### DIFF
--- a/MessageMedia.SDK.Messages/MessageMedia.SDK.Messages.csproj
+++ b/MessageMedia.SDK.Messages/MessageMedia.SDK.Messages.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <Version>1.1.1</Version>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <FileVersion>1.1.2.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">

--- a/MessageMedia.SDK.Messages/MessageMedia.SDK.Messages.nuspec
+++ b/MessageMedia.SDK.Messages/MessageMedia.SDK.Messages.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>MessageMedia.SDK.Messages</id>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <title>MessageMedia Messages SDK</title>
     <authors>MessageMedia Developers</authors>
     <owners>MessageMedia</owners>
@@ -18,7 +18,6 @@
     <dependencies>
       <dependency id="APIMATIC.SDK.Common" version="2.1.0.0" />
       <dependency id="Newtonsoft.Json" version="10.0.3"/>
-      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This was a dependency of the Tests project and is not neccessary for the SDK itself.
Further, by including it in the package, it prevented dotnet core projects from using the SDK, despite being otherwise .NET Standard 1.3